### PR TITLE
Update for Julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
 #  - osx
 julia:
-  - 0.6
-#  - nightly
+  - 1.0
+  - nightly
 notifications:
   email: false
 git:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,17 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 1
+  - julia_version: nightly
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -24,24 +25,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"LaTeXTabulars\"); Pkg.build(\"LaTeXTabulars\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"LaTeXTabulars\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/LaTeXTabulars.jl
+++ b/src/LaTeXTabulars.jl
@@ -3,6 +3,7 @@ module LaTeXTabulars
 using ArgCheck
 using DocStringExtensions
 using Parameters
+using Logging
 
 export Rule, CMidRule, MultiColumn, Tabular, latex_tabular
 
@@ -20,7 +21,7 @@ Print a the contents of `cell` to `io` as LaTeX.
     (eg rounding), use an `<: AbstractString`, eg `String` or `LaTeXString`.
 """
 function latex_cell(io::IO, cell::T) where T
-    info("Define a `latex_cell` for writing $T objects to LaTeX.")
+    @info "Define a `latex_cell` for writing $T objects to LaTeX."
     throw(MethodError(latex_cell, Tuple{IO, T}))
 end
 
@@ -79,8 +80,8 @@ Will be printed as `\\cmidrule[wd](trim)[left-right]`. When `wd` or `trim` is
 `nothing`, it is omitted. Use with the `booktabs` LaTeX package.
 """
 struct CMidRule
-    wd::Union{Void, AbstractString}
-    trim::Union{Void, AbstractString}
+    wd::Union{Nothing, AbstractString}
+    trim::Union{Nothing, AbstractString}
     left::Int
     right::Int
     function CMidRule(wd, trim, left, right)
@@ -110,7 +111,7 @@ function latex_line(io::IO, cells)
 end
 
 function latex_line(io::IO, M::AbstractMatrix)
-    for i in indices(M, 1)
+    for i in axes(M, 1)
         latex_line(io, M[i, :])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ squash_whitespace(string) = strip(replace(string, r"[ \n\t]+" => " "))
     @test latex_tabular(String, tb, tlines) ≅ tlatex
     tmp = tempname()
     latex_tabular(tmp, tb, tlines)
-    @test isfile(tmp) && readstring(tmp) ≅ tlatex
+    @test isfile(tmp) && read(tmp, String) ≅ tlatex
     @test read(tmp, String) ≅ tlatex
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,11 @@ using LaTeXTabulars
 # for testing
 using LaTeXTabulars: latex_cell
 
-using Base.Test
+using Test
 using LaTeXStrings
 
 "Normalize whitespace, for more convenient testing."
-squash_whitespace(string) = strip(replace(string, r"[ \n\t]+", " "))
+squash_whitespace(string) = strip(replace(string, r"[ \n\t]+" => " "))
 
 @test squash_whitespace(" something  \n with line  breaks \n  and   stuff \n") ==
     "something with line breaks and stuff"
@@ -40,13 +40,15 @@ squash_whitespace(string) = strip(replace(string, r"[ \n\t]+", " "))
                  \bottomrule
                  \end{tabular}"
 
+    tlatex = replace(tlatex, "\r\n"=>"\n")
     @test latex_tabular(String, tb, tlines) ≅ tlatex
     tmp = tempname()
     latex_tabular(tmp, tb, tlines)
     @test isfile(tmp) && readstring(tmp) ≅ tlatex
+    @test read(tmp, String) ≅ tlatex
 end
 
-@test_throws ArgumentError latex_cell(STDOUT, MultiColumn(2, :BAD, ""))
+@test_throws ArgumentError latex_cell(stdout, MultiColumn(2, :BAD, ""))
 @test_throws ArgumentError CMidRule(3, 1)     # not ≤
-@test_throws MethodError latex_cell(STDOUT, ("un", "supported"))
+@test_throws MethodError latex_cell(stdout, ("un", "supported"))
 @test_throws MethodError CMidRule(1, 1, 1, 2) # invalid types


### PR DESCRIPTION
This should work for Julia 1.0.

For the tests, on my Windows machine, the `raw` macro generates `\r\n`, not sure if that is Windows or Julia 0.7 to 1.0 doing that. Hence the `replace` call.