### PR TITLE
Longtables

### DIFF
--- a/src/LaTeXTabulars.jl
+++ b/src/LaTeXTabulars.jl
@@ -5,7 +5,7 @@ using DocStringExtensions
 using Parameters
 using Logging
 
-export Rule, CMidRule, MultiColumn, Tabular, latex_tabular
+export Rule, CMidRule, MultiColumn, Tabular, LongTable, latex_tabular
 
 
 # cells
@@ -195,5 +195,35 @@ function latex_tabular(filename::AbstractString, t::TabularLike, lines)
         latex_tabular(io, t, lines)
     end
 end
+
+struct LongTable <: TabularLike
+    "A column specification, eg `\"llrr\"`."
+    cols::AbstractString
+
+    "The table header, to be repeated at the top of each page, eg `[\"alpha\", \"beta\", \"gamma\"]`."
+    header
+end
+
+function latex_env_begin(io::IO, t::LongTable)
+    println(io, "\\begin{longtable}[c]{$(t.cols)}")
+    latex_line(io, Rule(:h))
+    latex_line(io, t.header)
+    latex_line(io, Rule(:h))
+    println(io, "\\endfirsthead")
+    println(io, "\\multicolumn{$(length(t.cols))}{l}")
+    println(io, "{{\\bfseries \\tablename\\ \\thetable{} --- continued from previous page}} \\\\")
+    latex_line(io, Rule(:h))
+    latex_line(io, t.header)
+    latex_line(io, Rule(:h))
+    println(io, "\\endhead")
+    latex_line(io, Rule(:h))
+    println(io, "\\multicolumn{$(length(t.cols))}{r}{{\\bfseries Continued on next page}} \\\\")
+    latex_line(io, Rule(:h))
+    println(io, "\\endfoot")
+    latex_line(io, Rule(:h))
+    println(io, "\\endlastfoot")
+end
+
+latex_env_end(io::IO, t::LongTable) = println(io, "\\end{longtable}")
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,3 +52,38 @@ end
 @test_throws ArgumentError CMidRule(3, 1)     # not ≤
 @test_throws MethodError latex_cell(stdout, ("un", "supported"))
 @test_throws MethodError CMidRule(1, 1, 1, 2) # invalid types
+
+@testset "longtable" begin
+    lt = LongTable("rrr", ["alpha", "beta", "gamma"])
+    tlines = [[1 2 3 ;
+               4.0 "5" "six"],
+              Rule(:h)]
+    tlatex = raw"\begin{longtable}[c]{rrr}
+                 \hline 
+                 alpha & beta & gamma \\
+                 \hline 
+                 \endfirsthead
+                 \multicolumn{3}{l}
+                 {{\bfseries \tablename\ \thetable{} --- continued from previous page}} \\
+                 \hline 
+                 alpha & beta & gamma \\
+                 \hline 
+                 \endhead
+                 \hline 
+                 \multicolumn{3}{r}{{\bfseries Continued on next page}} \\
+                 \hline 
+                 \endfoot
+                 \hline 
+                 \endlastfoot
+                 1 & 2 & 3 \\
+                 4.0 & 5 & six \\
+                 \hline 
+                 \end{longtable}"
+
+    tlatex = replace(tlatex, "\r\n"=>"\n")
+    @test latex_tabular(String, lt, tlines) ≅ tlatex
+    tmp = tempname()
+    latex_tabular(tmp, lt, tlines)
+    @test isfile(tmp) && read(tmp, String) ≅ tlatex
+    @test read(tmp, String) ≅ tlatex
+end


### PR DESCRIPTION
This PR adds support for producing long tables conforming to the [`longtable` LaTeX package](https://ctan.org/pkg/longtable?lang=en). From the documentation,

> Longtable al­lows you to write ta­bles that con­tinue to the next page. You can write cap­tions within the ta­ble (typ­i­cally at the start of the ta­ble), and head­ers and trail­ers for pages of ta­ble. Longtable ar­ranges that the columns on suc­ces­sive pages have the same widths. This last con­trasts with the su­per­fi­cially sim­i­lar su­pertab­u­lar pack­age.

See #4 for an example.