### PR TITLE
feat: add LineSpace() for \addlinespace command

### DIFF
--- a/src/LaTeXTabulars.jl
+++ b/src/LaTeXTabulars.jl
@@ -4,7 +4,7 @@ using ArgCheck: @argcheck
 using DocStringExtensions: SIGNATURES
 using UnPack: @unpack
 
-export Rule, CMidRule, MultiColumn, MultiRow, Tabular, LongTable, latex_tabular
+export Rule, CMidRule, LineSpace, MultiColumn, MultiRow, Tabular, LongTable, latex_tabular
 
 
 # cells
@@ -143,6 +143,26 @@ function latex_line(io::IO, lines::Tuple)
     for line in lines
         latex_line(io, line)
     end
+end
+
+
+"""
+    LineSpace([wd])
+
+Prints `\\addlinespace[wd]`. When `wd` is `nothing`, it is omitted.
+Use with the `booktabs` LaTeX package.
+"""
+struct LineSpace
+    wd::Union{Nothing, AbstractString}
+end
+
+LineSpace() = LineSpace(nothing)
+
+function latex_line(io::IO, ls::LineSpace)
+    @unpack wd = ls
+    print(io, "\\addlinespace")
+    wd ≠ nothing && print(io, "[$(wd)]")
+    println(io)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ squash_whitespace(string) = strip(replace(string, r"[ \n\t]+" => " "))
               [4.0 "5" "six";   # a matrix
                7 8 9],
               [MultiRow(2, :c, "a11 \\& a21"), "a12", "a13"],
+              LineSpace(),
               ["", "a22", "a23"],
               (CMidRule(1, 2), CMidRule("lr", 1, 1)), # just to test tuples
               [MultiColumn(2, :c, "centered")],       # ragged!
@@ -36,6 +37,7 @@ squash_whitespace(string) = strip(replace(string, r"[ \n\t]+" => " "))
                  4.0 & 5 & six \\
                  7 & 8 & 9 \\
                  \multirow[c]{2}{*}{a11 \& a21} & a12 & a13 \\
+                 \addlinespace
                  & a22 & a23 \\ \cmidrule{1-2} \cmidrule(lr){1-1}
                  \multicolumn{2}{c}{centered} \\
                  \bottomrule


### PR DESCRIPTION
This PR adds support for `\addlinespace[<wd>]` in [booktabs](https://ctan.org/pkg/booktabs) as `LineSpace([wd])`. See #17.