### PR TITLE
WIP: formatting reorganization

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,3 +46,4 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.10' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,27 @@
+# see https://juliadocs.github.io/Documenter.jl/dev/man/hosting/#GitHub-Actions
+# add this file to the repository once you set up authentication as described in the Documenter manual
+
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1.10'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
+        run: julia --project=docs/ docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /docs/build
 /docs/Manifest.toml
 /test/coverage/Manifest.toml
+/test/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,12 @@ version = "0.1.3"
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+LaTeXEscapes = "cf6549fa-34fa-4b85-907d-0f184605242c"
 
 [compat]
 ArgCheck = "1, 2"
 DocStringExtensions = "0.8, 0.9"
+LaTeXEscapes = "0.2.0"
 julia = "1.8"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ LaTeXEscapes = "cf6549fa-34fa-4b85-907d-0f184605242c"
 ArgCheck = "1, 2"
 DocStringExtensions = "0.8, 0.9"
 LaTeXEscapes = "0.2.0"
-julia = "1.8"
+julia = "1.10"
 
 [extras]
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"

--- a/README.md
+++ b/README.md
@@ -8,45 +8,4 @@ Write tabular data from Julia in LaTeX format.
 
 This is a *very thin wrapper*, basically for avoiding some loops and repeatedly used strings. It assumes that you know how the LaTeX `tabular` environment works, and you have formatted the cells to strings if you want anything fancy like rounding or alignment on the decimal dot.
 
-This is how it works:
-
-```julia
-using LaTeXTabulars
-using LaTeXStrings               # not a dependency, but works nicely
-latex_tabular("/tmp/table.tex",
-              Tabular("lcl"),
-              [Rule(:top),
-               [L"\alpha", L"\beta", "sum"],
-               Rule(:mid),
-               [1, 2, 3],
-               Rule(),           # a nice \hline to make it ugly
-               [4.0 "5" "six";   # a matrix
-                7 8 9],
-               CMidRule(1, 2),
-               [MultiColumn(2, :c, "centered")], # ragged!
-               Rule(:bottom)])
-```
-will write something like
-```LaTeX
-\begin{tabular}{lcl}
-\toprule
-$\alpha$ & $\beta$ & sum \\
-\midrule
-1 & 2 & 3 \\
-\hline
-4.0 & 5 & six \\
-7 & 8 & 9 \\
-\cmidrule{1-2}
-\multicolumn{2}{c}{centered} \\
-\bottomrule
-\end{tabular}
-```
-to `/tmp/table.tex`.
-
-Note that the position specifier `lcl` is not checked for valid syntax or consitency with the contents, just emitted as is, allowing the use of [dcolumn](https://ctan.org/pkg/dcolumn) or similar, and the number of cells in each line is not checked for consistency. This means that the usual LaTeX rules apply: fewer cells than position specifiers gives you a ragged table, more cells and LaTeX will complain about having to change `&` to `\\`.
-
-See `?latex_tabular` for the documentation of the syntax, and the unit tests for examples.
-
-Rule types in [booktabs](https://ctan.org/pkg/booktabs) are supported. Vertical rules of any kind are *not explicitly supported* and it would be difficult to convince me to add them. The documentation of [booktabs](https://ctan.org/pkg/booktabs) should explain why. That said, if you insist, you can use a cell like `\vline text`.
-
-The other tabular type currently implemented is `LongTable`. The code is generic, so [other tabular-like types](https://en.wikibooks.org/wiki/LaTeX/Tables) can be easily added, just open an issue.
+The package is documented with a manual and docstrings.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LaTeXCompilers = "90294288-587b-4593-a557-cb1db79f8ded"
+LaTeXEscapes = "cf6549fa-34fa-4b85-907d-0f184605242c"
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+LaTeXTabulars = "266f59ce-6e72-579c-98bb-27b39b5c037e"
 
 [compat]
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,21 @@
+# see documentation at https://juliadocs.github.io/Documenter.jl/stable/
+
+using Documenter, LaTeXTabulars
+
+makedocs(
+    modules = [LaTeXTabulars],
+    format = Documenter.HTML(; prettyurls = get(ENV, "CI", nothing) == "true"),
+    authors = "Tamás K. Papp",
+    sitename = "LaTeXTabulars.jl",
+    pages = Any["index.md"],
+    # strict = true,
+    # clean = true,
+    # checkdocs = :exports,
+)
+
+# Some setup is needed for documentation deployment, see “Hosting Documentation” and
+# deploydocs() in the Documenter manual for more information.
+deploydocs(
+    repo = "github.com/tpapp/LaTeXTabulars.jl.git",
+    push_preview = true
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,9 +8,6 @@ makedocs(
     authors = "Tamás K. Papp",
     sitename = "LaTeXTabulars.jl",
     pages = Any["index.md"],
-    # strict = true,
-    # clean = true,
-    # checkdocs = :exports,
 )
 
 # Some setup is needed for documentation deployment, see “Hosting Documentation” and

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,159 @@
 # LaTeXTabulars
 
-*Documentation goes here.*
+```@setup all
+using LaTeXCompilers, LaTeXTabulars
+
+struct ShowMe
+    content
+end
+
+function Base.show(out_io::IO, ::MIME"image/svg+xml", showme::ShowMe)
+    (; content) = showme
+    LaTeXCompilers.svg(out_io) do io
+        print(io,
+              raw"""
+\documentclass[12pt]{standalone}
+\usepackage{booktabs}
+\usepackage{graphicx}
+\begin{document}
+\scalebox{2}{
+""")
+        print(io, content)
+        print(io, raw"}\end{document}")
+    end
+end
+```
 
 ```@docs
 LaTeXTabulars.LaTeXTabulars
 ```
+
+## Writing tables
+
+The main entry point of the package is [`latex_tabular`](@ref), which takes a *destination* (a filename, or `String`), a *table specification* (eg [`Tabular`](@ref) and an *iterable*, which is rendered elementwise using the following rules:
+
+1. special objects like `Rule` emit the corresponding ``\LaTeX`` code,
+2. vectors and iterables emit a row of cells (not checked for length),
+3. matrices are treated as rows of vectors,
+4. `Tuple`s are “splat” into place, which is useful for writing functions that format tables.
+
+!!! note
+    Some examples in this manual, eg the one below, use the
+    [`booktabs`](https://ctan.org/pkg/booktabs/) LaTeX package. If you
+    are including them in a ``\LaTeX`` document, make sure you add
+    `\usepackage{booktabs}`.
+
+```@example all
+latex_tabular(String, Tabular("lr"),
+              [Rule(:top),
+              ["critter", "count"],
+              Rule(:mid),
+               ["cats", 5],
+               ["dogs", 7],
+               Rule(:bottom)]) 
+(z = ans; print(z)) # hide
+```
+which renders as
+```@example all
+ShowMe(z) # hide
+```
+
+The simplest table specification is [`Tabular`](@ref).
+```@docs
+Tabular
+```
+Long tables are also supported.
+```@docs
+LongTable
+```
+Other table types would be simple to add, see [adding extensions](@ref extending-the-code).
+
+```@docs
+latex_tabular
+```
+
+## Cells
+
+Tables contain formatting (eg rules) and *cells*.
+
+Cells can be
+
+1. *strings* (which are escaped when written into LaTeX, so eg `%` is replaced by `\%`),
+2. LaTeX wrappers like `LaTeXEscapes.LaTeX` and `LaTeXStrings.LaTeXString`, 
+3. and arbitrary Julia objects, which are converted with `string`, then escaped.
+
+These rules apply to all cells, including [`MultiColumn`](@ref) and other special wrappers.
+
+### Inserting LaTeX code
+
+LaTeX code can be inserted into tables using the [LaTeXEscapes.jl](https://github.com/tpapp/LaTeXEscapes.jl) and [LaTeXStrings.jl](https://github.com/JuliaStrings/LaTeXStrings.jl) packages, which use the `lx"..."[m]` and `L"..."` read string macros, respectively. The difference between the two packages is that `lx"..."` does not create values which are subtypes of string, and does not wrap in math mode inless you add the `m` flag. Naturally, the explicit wrapper types (eg `LaTeXEscapes.LaTeX`) can be used, too.
+
+```@example all
+using LaTeXEscapes, LaTeXStrings
+latex_tabular(String, Tabular("ll"),
+               [[lx"\alpha"m, L"\beta"],
+                [LaTeX(raw"$\gamma$"), "100%"]]) 
+(z = ans; print(z)) # hide
+```
+which renders as
+```@example all
+ShowMe(z) # hide
+```
+
+## Special constructs
+
+```@docs
+Rule
+CMidRule
+```
+
+```@docs
+MultiColumn
+MultiRow
+```
+
+### Formatting
+
+For the purposes of this package, *formatting* is the conversion of Julia values to strings or `LaTeX` code.
+
+A *formatter* is a callable that converts its arguments to the above, or leaves it alone. This allows the user to *chain* formatters.
+
+The user can either format the arguments to [`latex_tabular`](@ref) **directly**, which allows more flexibility, or provide a formatter via the `formatter` keyword,  which defaults to [`DEFAULT_FORMATTER`](@ref), which is initialized with [`SimpleCellFormatter`](@ref).
+
+```@example all
+latex_tabular(String, Tabular("ll"),
+               [[Inf, -Inf],
+                [NaN, -0.0],
+                [missing, nothing]])
+(z = ans; print(z)) # hide
+```
+which renders as
+```@example all
+ShowMe(z) # hide
+```
+
+```@docs
+DEFAULT_FORMATTER
+SimpleCellFormatter
+```
+
+## [Adding extensions](@id extending-the-code)
+
+You can extend the functionality of this package in various ways:
+
+1. add **formatters** (see eg [`SimpleCellFormatter`](@ref)),
+2. add **rule-like objects**, for which you have to define a [`LaTeXTabulars.latex_line`](@ref) method,
+3. add a **new table type**, for which it is recommended that you define [`LaTeXTabulars.latex_env_begin`](@ref) and [`LaTeXTabulars.latex_env_end`](@ref). See the [`LongTable`](@ref) methods for an example.
+
+!!! note
+     It is very unlikely that you have to add methods for [`LaTeXTabulars.latex_cell`](@ref) or [`LaTeXTabulars.latex_tabular`](@ref).
+
+```@docs
+LaTeXTabulars.latex_cell
+LaTeXTabulars.latex_line
+LaTeXTabulars.latex_env_begin
+LaTeXTabulars.latex_env_end
+```
+
+!!! note
+     Rule types in [booktabs](https://ctan.org/pkg/booktabs) are supported. Vertical rules of any kind are *not explicitly supported* and it would be difficult to convince me to add them. The documentation of [booktabs](https://ctan.org/pkg/booktabs) should explain why. That said, if you insist, you can use a cell like `\vline text`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,7 @@
+# LaTeXTabulars
+
+*Documentation goes here.*
+
+```@docs
+LaTeXTabulars.LaTeXTabulars
+```

--- a/src/LaTeXTabulars.jl
+++ b/src/LaTeXTabulars.jl
@@ -2,32 +2,85 @@ module LaTeXTabulars
 
 using ArgCheck: @argcheck
 using DocStringExtensions: SIGNATURES
+using LaTeXEscapes: LaTeX, @lx_str, print_escaped
 
-export Rule, CMidRule, MultiColumn, MultiRow, Tabular, LongTable, latex_tabular
+export DEFAULT_FORMATTER, SimpleCellFormatter, Rule, CMidRule, MultiColumn, MultiRow,
+    Tabular, LongTable, latex_tabular
 
-# cells
+####
+#### cell formatters
+####
+
+struct SimpleCellFormatter
+    inf
+    minus_inf
+    NaN
+    negative_zero
+    nothing
+    missing
+    @doc """
+    $(SIGNATURES)
+
+    A simple formatter that replaces some commonly used values used in displaying data.
+
+    Each field below should contain a string or a `LaTeX` code (otherwise, it is emitted
+    as an escaped string).
+    """
+    function SimpleCellFormatter(; inf = lx"\infty"m, minus_inf = lx"-\infty"m, NaN = "NaN",
+                                 negative_zero = "false", nothing = "---", missing = "---")
+        new(inf, minus_inf, NaN, negative_zero, nothing, missing)
+    end
+end
+
+"The default formatter."
+DEFAULT_FORMATTER = SimpleCellFormatter(;)
+
+function (formatter::SimpleCellFormatter)(x)
+    if isnothing(x)
+        formatter.nothing
+    elseif ismissing(x)
+        formatter.missing
+    elseif x isa Real
+        if iszero(x) && signbit(x)
+            formatter.negative_zero
+        elseif x == Inf
+            formatter.inf
+        elseif x == -Inf
+            formatter.minus_inf
+        elseif isnan(x)
+            formatter.NaN
+        else
+            x
+        end
+        x
+    end
+end
 
 """
 $(SIGNATURES)
 
-Print a the contents of `cell` to `io` as LaTeX.
+Write a the contents of `cell` to `io` as LaTeX.
+
+`formatter` is callable that is used to format cells that are not already
+`::AbstractString` or `::LaTeX`. If either of these are returned by the formatter, they
+are written into the LaTeX output, otherwise they are formatted as strings (and escaped
+asnecessary when written into LaTeX).
 
 !!! NOTE
 
-    Methods are defined for some specific types, but if you want full control
-    (eg rounding), use an `<: AbstractString`, eg `String` or `LaTeXString`.
+    If you want to make simple formatting changes, it is best to write your own
+    `formatter`.
 """
-function latex_cell(io::IO, cell::T) where T
-    @info "Define a `latex_cell` for writing $T objects to LaTeX."
-    throw(MethodError(latex_cell, Tuple{IO, T}))
+function latex_cell(io::IO, x, formatter)
+    print_escaped(io, formatter(x))
 end
 
-latex_cell(io::IO, x::Real) = print(io, string(x))
+latex_cell(io::IO, s::AbstractString, _) = print_escaped(io, s)
 
-latex_cell(io::IO, s::AbstractString) = print(io, s)
+latex_cell(io::IO, l::LaTeX, _) = print_escaped(io, l)
 
 """
-    MultiColumn(n, pos, cell)
+`MultiColumn(n, pos, cell)`
 
 For `\\multicolumn{n}{pos}{cell}`. Use the symbols `:l`, `:c`, `:r` for `pos`.
 """
@@ -37,12 +90,12 @@ struct MultiColumn
     cell
 end
 
-function latex_cell(io::IO, mc::MultiColumn)
+function latex_cell(io::IO, mc::MultiColumn, formatter)
     (; n, pos, cell) = mc
     @argcheck(pos ∈ (:l, :c, :r),
               "$(pos) is not a recognized position. Use :l, :c, :r.")
     print(io, "\\multicolumn{$(n)}{$(pos)}{")
-    latex_cell(io, mc.cell)
+    latex_cell(io, cell, formatter)
     print(io, "}")
 end
 
@@ -61,12 +114,12 @@ end
 
 MultiRow(n, vpos, cell; width="*") = MultiRow(n, vpos, cell, width)
 
-function latex_cell(io::IO, mr::MultiRow)
-    (; vpos, n, width) = mr
+function latex_cell(io::IO, mr::MultiRow, formatter)
+    (; vpos, n, width, cell) = mr
     @argcheck(vpos ∈ (:t, :c, :b),
               "$(vpos) is not a recognized position. Use :t, :c, :b.")
     print(io, "\\multirow[$vpos]{$(n)}{$width}{")
-    latex_cell(io, mr.cell)
+    latex_cell(io, cell, formatter)
     print(io, "}")
 end
 
@@ -84,27 +137,27 @@ prints `\\toprule`. To obtain a `\\hline`, use `Rule{:h}`.
 """
 Rule(kind::Symbol = :h) = Rule{kind}()
 
-latex_line(io::IO, ::Rule{:top}) = println(io, "\\toprule ")
+latex_line(io::IO, ::Rule{:top}, _) = println(io, "\\toprule")
 
-latex_line(io::IO, ::Rule{:mid}) = println(io, "\\midrule ")
+latex_line(io::IO, ::Rule{:mid}, _) = println(io, "\\midrule")
 
-latex_line(io::IO, ::Rule{:bottom}) = println(io, "\\bottomrule ")
+latex_line(io::IO, ::Rule{:bottom}, _) = println(io, "\\bottomrule")
 
-latex_line(io::IO, ::Rule{:h}) = println(io, "\\hline ")
+latex_line(io::IO, ::Rule{:h}, _) = println(io, "\\hline")
 
-latex_line(io::IO, r::Rule) = error("Don't know how to print $(typeof(r)).")
+latex_line(io::IO, r::Rule, _) = error("Don't know how to print $(typeof(r)).")
 
-"""
-    CMidRule([wd], [trim], left, right)
-
-Will be printed as `\\cmidrule[wd](trim)[left-right]`. When `wd` or `trim` is
-`nothing`, it is omitted. Use with the `booktabs` LaTeX package.
-"""
 struct CMidRule
-    wd::Union{Nothing, AbstractString}
-    trim::Union{Nothing, AbstractString}
+    wd
+    trim
     left::Int
     right::Int
+    @doc """
+    `CMidRule([wd], [trim], left, right)`
+
+    Will be printed as `\\cmidrule[wd](trim)[left-right]`. When `wd` or `trim` is
+    `nothing`, it is omitted. Use with the `booktabs` LaTeX package.
+    """
     function CMidRule(wd, trim, left, right)
         @argcheck 1 ≤ left ≤ right
         new(wd, trim, left, right)
@@ -115,34 +168,34 @@ CMidRule(trim, left, right) = CMidRule(nothing, trim, left, right)
 
 CMidRule(left, right) = CMidRule(nothing, left, right)
 
-function latex_line(io::IO, rule::CMidRule)
+function latex_line(io::IO, rule::CMidRule, _)
     (; wd, trim, left, right) = rule
-    print(io, "\\cmidrule")
-    wd ≠ nothing && print(io, "[$(wd)]")
-    trim ≠ nothing && print(io, "($(trim))")
-    print(io, "{$(left)-$(right)} ") # NOTE trailing space important
+    print(io, raw"\cmidrule")
+    wd ≡ nothing || print(io, "[$(print_escaped(String, wd))]")
+    trim ≡ nothing || print(io, "($(print_escaped(String, trim)))")
+    # NOTE trailing space important
+    print(io, "{$(print_escaped(String, left))-$(print_escaped(String, right))} ")
 end
 
-function latex_line(io::IO, cells)
+function latex_line(io::IO, cells, formatter)
     for (column, cell) in enumerate(cells)
         column == 1 || print(io, " & ")
-        latex_cell(io, cell)
+        latex_cell(io, cell, formatter)
     end
     println(io, " \\\\")
 end
 
-function latex_line(io::IO, M::AbstractMatrix)
-    for i in axes(M, 1)
-        latex_line(io, M[i, :])
+function latex_line(io::IO, matrix::AbstractMatrix, formatter)
+    for row in eachrow(matrix)
+        latex_line(io, row, formatter)
     end
 end
 
-function latex_line(io::IO, lines::Tuple)
+function latex_line(io::IO, lines::Tuple, formatter)
     for line in lines
-        latex_line(io, line)
+        latex_line(io, line, formatter)
     end
 end
-
 
 # tabular and similar environments
 
@@ -158,9 +211,19 @@ struct Tabular <: TabularLike
     cols::AbstractString
 end
 
-latex_env_begin(io::IO, t::Tabular) = println(io, "\\begin{tabular}{$(t.cols)}")
+"""
+$(SIGNATURES)
 
-latex_env_end(io::IO, t::Tabular) = println(io, "\\end{tabular}")
+Write the beginning of the environment `t`, using `formatter`.
+"""
+latex_env_begin(io::IO, t::Tabular, formatter) = println(io, "\\begin{tabular}{$(t.cols)}")
+
+"""
+$(SIGNATURES)
+
+Write the end of the environment `t`, using `formatter`.
+"""
+latex_env_end(io::IO, t::Tabular, formatter) = println(io, "\\end{tabular}")
 
 """
 $(SIGNATURES)
@@ -179,39 +242,50 @@ Each `line` in `lines` can be
 
 - a matrix, each row of which is treated as a line.
 
+Constructs which contain cells are printed by `latex_cell`, using the
+`formatter`, which leaves strings and `LaTeX` cells as is.
+
+It is recommended that formatting parts of the table is done directly on the arguments,
+using a suitable formatter. See the manual for examples.
+
 See [`latex_cell`](@ref) for the kinds of cell supported (particularly
 [`MultiColumn`](@ref), but for full formatting control, use an `String` or
 `LaTeXString` for cells.
 """
-function latex_tabular(io::IO, t::TabularLike, lines)
-    latex_env_begin(io, t)
+function latex_tabular(io::IO, t::TabularLike, lines;
+                       formatter = DEFAULT_FORMATTER)
+    latex_env_begin(io, t, formatter)
     for line in lines
-        latex_line(io, line)
+        latex_line(io, line, formatter)
     end
-    latex_env_end(io, t)
+    latex_env_end(io, t, formatter)
 end
 
-latex_tabular(io::IO, t::TabularLike, lines::AbstractMatrix) =
-    latex_tabular(io, t, [lines])
+function latex_tabular(io::IO, t::TabularLike, lines::AbstractMatrix;
+                       formatter = DEFAULT_FORMATTER)
+    latex_tabular(io, t, [lines]; formatter)
+end
 
 """
 $(SIGNATURES)
 
 LaTeX output as a string. See other method for the other arguments.
 """
-function latex_tabular(::Type{String}, t::TabularLike, lines)
+function latex_tabular(::Type{String}, t::TabularLike, lines;
+                       formatter = DEFAULT_FORMATTER)
     io = IOBuffer()
-    latex_tabular(io, t, lines)
+    latex_tabular(io, t, lines; formatter)
     String(take!(io))
 end
 
 """
-    $(SIGNATURES)
+$(SIGNATURES)
 
 Write a `tabular`-like LaTeX environment to `filename`, which is **overwritten**
 if it already exists.
 """
-function latex_tabular(filename::AbstractString, t::TabularLike, lines)
+function latex_tabular(filename::AbstractString, t::TabularLike, lines;
+                       formatter = DEFAULT_FORMATTER)
     open(filename, "w") do io
         latex_tabular(io, t, lines)
     end
@@ -220,7 +294,6 @@ end
 struct LongTable <: TabularLike
     "A column specification, eg `\"llrr\"`."
     cols::AbstractString
-
     """
     The table header, to be repeated at the top of each page, supplied an iterable of cells,
     eg `[\"alpha\", \"beta\", \"gamma\"]`.
@@ -228,26 +301,26 @@ struct LongTable <: TabularLike
     header
 end
 
-function latex_env_begin(io::IO, t::LongTable)
+function latex_env_begin(io::IO, t::LongTable, formatter)
     println(io, "\\begin{longtable}[c]{$(t.cols)}")
-    latex_line(io, Rule(:h))
-    latex_line(io, t.header)
-    latex_line(io, Rule(:h))
+    latex_line(io, Rule(:h), formatter)
+    latex_line(io, t.header, formatter)
+    latex_line(io, Rule(:h), formatter)
     println(io, "\\endfirsthead")
     println(io, "\\multicolumn{$(length(t.cols))}{l}")
     println(io, "{{\\bfseries \\tablename\\ \\thetable{} --- continued from previous page}} \\\\")
-    latex_line(io, Rule(:h))
-    latex_line(io, t.header)
-    latex_line(io, Rule(:h))
+    latex_line(io, Rule(:h), formatter)
+    latex_line(io, t.header, formatter)
+    latex_line(io, Rule(:h), formatter)
     println(io, "\\endhead")
-    latex_line(io, Rule(:h))
+    latex_line(io, Rule(:h), formatter)
     println(io, "\\multicolumn{$(length(t.cols))}{r}{{\\bfseries Continued on next page}} \\\\")
-    latex_line(io, Rule(:h))
+    latex_line(io, Rule(:h), formatter)
     println(io, "\\endfoot")
-    latex_line(io, Rule(:h))
+    latex_line(io, Rule(:h), formatter)
     println(io, "\\endlastfoot")
 end
 
-latex_env_end(io::IO, t::LongTable) = println(io, "\\end{longtable}")
+latex_env_end(io::IO, t::LongTable, _) = println(io, "\\end{longtable}")
 
 end # module

--- a/src/LaTeXTabulars.jl
+++ b/src/LaTeXTabulars.jl
@@ -1,7 +1,10 @@
+"""
+$(DocStringExtensions.README)
+"""
 module LaTeXTabulars
 
 using ArgCheck: @argcheck
-using DocStringExtensions: SIGNATURES
+using DocStringExtensions: SIGNATURES, DocStringExtensions
 using LaTeXEscapes: LaTeX, @lx_str, print_escaped
 
 export DEFAULT_FORMATTER, SimpleCellFormatter, Rule, CMidRule, MultiColumn, MultiRow,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+LaTeXEscapes = "cf6549fa-34fa-4b85-907d-0f184605242c"
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using LaTeXTabulars, Test, LaTeXStrings
+using LaTeXTabulars, Test, LaTeXStrings, LaTeXEscapes
 
 # for testing
 using LaTeXTabulars: latex_cell
@@ -12,17 +12,16 @@ squash_whitespace(string) = strip(replace(string, r"[ \n\t]+" => " "))
 "Comparison using normalized whitespace. For testing."
 ≅(a, b) = squash_whitespace(a) == squash_whitespace(b)
 
-
 @testset "tabular" begin
     tb = Tabular("lcl")
     tlines = [Rule(:top),
-              [L"\alpha", L"\beta", "sum"],
+              [lx"\alpha"m, L"\beta", "sum"],
               Rule(:mid),
               [1, 2, 3],
               Rule(),           # a nice \hline to make it ugly
               [4.0 "5" "six";   # a matrix
                7 8 9],
-              [MultiRow(2, :c, "a11 \\& a21"), "a12", "a13"],
+              [MultiRow(2, :c, lx"a11 \& a21"), "a12", "a13"],
               ["", "a22", "a23"],
               (CMidRule(1, 2), CMidRule("lr", 1, 1)), # just to test tuples
               [MultiColumn(2, :c, "centered")],       # ragged!
@@ -49,10 +48,9 @@ squash_whitespace(string) = strip(replace(string, r"[ \n\t]+" => " "))
     @test read(tmp, String) ≅ tlatex
 end
 
-@test_throws ArgumentError latex_cell(stdout, MultiColumn(2, :BAD, ""))
+@test_throws "BAD is not a recognized position" latex_cell(stdout, MultiColumn(2, :BAD, ""), identity)
 @test_throws ArgumentError CMidRule(3, 1)     # not ≤
-@test_throws MethodError latex_cell(stdout, ("un", "supported"))
-@test_throws MethodError CMidRule(1, 1, 1, 2) # invalid types
+@test_throws MethodError CMidRule(1, 1, "a fish", 2) # invalid types
 
 @testset "longtable" begin
     lt = LongTable("rrr", ["alpha", "beta", "gamma"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,10 +30,10 @@ squash_whitespace(string) = strip(replace(string, r"[ \n\t]+" => " "))
                  \toprule
                  $\alpha$ & $\beta$ & sum \\
                  \midrule
-                 1 & 2 & 3 \\
+                 $1$ & $2$ & $3$ \\
                  \hline
-                 4.0 & 5 & six \\
-                 7 & 8 & 9 \\
+                 $4.0$ & 5 & six \\
+                 $7$ & $8$ & $9$ \\
                  \multirow[c]{2}{*}{a11 \& a21} & a12 & a13 \\
                  & a22 & a23 \\ \cmidrule{1-2} \cmidrule(lr){1-1}
                  \multicolumn{2}{c}{centered} \\
@@ -74,8 +74,8 @@ end
                  \endfoot
                  \hline
                  \endlastfoot
-                 1 & 2 & 3 \\
-                 4.0 & 5 & six \\
+                 $1$ & $2$ & $3$ \\
+                 $4.0$ & 5 & six \\
                  \hline
                  \end{longtable}"
 


### PR DESCRIPTION
- [x] use LaTeXEscapes for LaTeX code injection
- [x] add default formatter, fixes #19 
- [ ] documentation
    1. setup rendering for tables in docs
    2. user API: document invocation of `latex_tabular`, formatting, formatters, how they can be chained
    3. add another formatter example
    4. document the internal API, eg how another table type can be added